### PR TITLE
Fix some typos in JavaDoc comments

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -291,7 +291,7 @@ public interface ChronicleQueue extends Closeable {
     }
 
     /**
-     * Returns the source id. Source is is used to identify the queue in {@link net.openhft.chronicle.wire.MessageHistory}
+     * Returns the source id. Source is used to identify the queue in {@link net.openhft.chronicle.wire.MessageHistory}
      * <p>
      * The source id is non-negative.
      *

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
@@ -79,7 +79,7 @@ public interface ExcerptAppender extends ExcerptCommon<ExcerptAppender>, Marshal
      * Pre-touching involves accessing pages of files/memory that are likely accessed in a
      * near future and may also involve accessing/acquiring future cycle files.
      * <p>
-     * We suggest this code is called from a background thread [ not you main
+     * We suggest this code is called from a background thread [ not your main
      * business thread ], it must be called from the same thread that created it, as the call to
      * pretouch() is not thread safe. For example :
      * <p>

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
@@ -57,7 +57,7 @@ public interface ExcerptTailer extends ExcerptCommon<ExcerptTailer>, Marshallabl
      * <p>
      * This method is the ExcerptTailer equivalent of {@link net.openhft.chronicle.wire.WireIn#readingDocument()}
      *
-     * @param includeMetaData if the DocumentContext shall be meta data aware.
+     * @param includeMetaData if the DocumentContext shall be metadata aware.
      * @return the document context
      */
     @NotNull
@@ -136,8 +136,8 @@ public interface ExcerptTailer extends ExcerptCommon<ExcerptTailer>, Marshallabl
      * current millisecond, toEnd() may not see it, This is because for performance reasons, the
      * queue.lastCycle() is cached, as finding the last cycle is expensive, it requires asking the
      * directory for the Files.list() so, this cache is only refreshed if the call toEnd() is in a
-     * new millisecond. Hence a whole milliseconds with of data could be added to the
-     * chronicle-queue that toEnd() won’t see. For appenders that that are using the same queue
+     * new millisecond. Hence, a whole milliseconds with of data could be added to the
+     * chronicle-queue that toEnd() won’t see. For appenders that are using the same queue
      * instance ( and with then same JVM ), they can be informed that the last cycle has
      * changed, this will yield better results, but atomicity can still not be guaranteed.
      *
@@ -171,7 +171,7 @@ public interface ExcerptTailer extends ExcerptCommon<ExcerptTailer>, Marshallabl
      *
      * @param direction which is either of NONE, FORWARD, BACKWARD
      * @return this ExcerptTailer
-     * @throws NullPointerException if the provide {@code direction} is {@code null}
+     * @throws NullPointerException if the provided {@code direction} is {@code null}
      */
     @NotNull
     ExcerptTailer direction(@NotNull TailerDirection direction);

--- a/src/main/java/net/openhft/chronicle/queue/RollCycle.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycle.java
@@ -99,7 +99,7 @@ public interface RollCycle {
     /**
      * Returns the sequence number for the provided {@code index}.
      * <p>
-     * An index is comprised of both a cycle and a sequence number but the way the index is composed of said properties may vary. This method
+     * An index comprises both a cycle and a sequence number but the way the index is composed of said properties may vary. This method
      * decomposes the provided {@code index} and extracts the sequence number.
      *
      * @param index to use to extract the sequence number
@@ -110,7 +110,7 @@ public interface RollCycle {
     /**
      * Returns the cycle for the given {@code index}.
      * <p>
-     * An index is comprised of both a cycle and a sequence number but the way the index is composed of said properties may vary. This method
+     * An index comprises both a cycle and a sequence number but the way the index is composed of said properties may vary. This method
      * decomposes the provided {@code index} and extracts the cycle.
      *
      * @param index to use when extracting the cycle


### PR DESCRIPTION
A few corrections that stood out for me while reading the docs.